### PR TITLE
Make sure pytorch conv2d weights are contiguous

### DIFF
--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -434,7 +434,7 @@ def test_op_conv(Z_shape, W_shape, stride, padding, backward, device):
     Ztch.requires_grad=True
     Wtch = torch.Tensor(_W).float()
     Wtch.requires_grad=True
-    out = torch.nn.functional.conv2d(Ztch.permute(0, 3, 1, 2), Wtch.permute(3, 2, 0, 1), padding=padding, stride=stride)
+    out = torch.nn.functional.conv2d(Ztch.permute(0, 3, 1, 2), Wtch.permute(3, 2, 0, 1).contiguous(), padding=padding, stride=stride)
     out2 = out.sum()
     if backward:
         out2.backward()


### PR DESCRIPTION
__Environment__: MacOS 12.2, M1, newly installed pytorch via `pip3 install pytorch`.

I kept running into the following error when testing conv2d:

```
FAILED tests/test_conv.py::test_op_conv[backward-needle.backend_ndarray.ndarray_backend_cpu-Z_shape14-W_shape14-1-0] - RuntimeError: slow_conv2d: grad_weight must be contiguous
```

Forcing the weights to be contiguous resolves the issue, apparently PyTorch doesn't do it internally on my machine.